### PR TITLE
Fix issue with build meta-data not being parsed without a pre-release version

### DIFF
--- a/src/lib/semantic_version_v2.cpp
+++ b/src/lib/semantic_version_v2.cpp
@@ -175,11 +175,11 @@ Version::Version(const string& s)
   size_t buildLoc = part.find_first_of("+");
 
   if (preLoc != string::npos) {
-    m_prereleaseVersion = part.substr(preLoc, buildLoc);
+    m_prereleaseVersion = part.substr(preLoc + 1, buildLoc);
   }
 
   if (buildLoc != string::npos) {
-    m_buildVersion = part.substr(buildLoc, string::npos);
+    m_buildVersion = part.substr(buildLoc + 1, string::npos);
   }
 }
 

--- a/src/lib/semantic_version_v2.cpp
+++ b/src/lib/semantic_version_v2.cpp
@@ -175,7 +175,7 @@ Version::Version(const string& s)
   const size_t buildLoc = part.find_first_of("+");
 
   if (preLoc != string::npos) {
-    const ize_t length = (buildLoc != string::npos ) ? (buildLoc -1) - preLoc : string::npos;
+    const size_t length = (buildLoc != string::npos ) ? (buildLoc -1) - preLoc : string::npos;
     m_prereleaseVersion = part.substr(preLoc+1, length);
   }
 

--- a/src/lib/semantic_version_v2.cpp
+++ b/src/lib/semantic_version_v2.cpp
@@ -171,8 +171,8 @@ Version::Version(const string& s)
   if (!getline(ss, part)) return;
   m_patchVersion = static_cast<unsigned int>(strtoul(part.c_str(), 0, 0));
 
-  int preLoc = part.find_first_of("-");
-  int buildLoc = part.find_first_of("+");
+  size_t preLoc = part.find_first_of("-");
+  size_t buildLoc = part.find_first_of("+");
 
   if (preLoc != string::npos) {
     m_prereleaseVersion = part.substr(preLoc, buildLoc);

--- a/src/lib/semantic_version_v2.cpp
+++ b/src/lib/semantic_version_v2.cpp
@@ -171,11 +171,11 @@ Version::Version(const string& s)
   if (!getline(ss, part)) return;
   m_patchVersion = static_cast<unsigned int>(strtoul(part.c_str(), 0, 0));
 
-  size_t preLoc = part.find_first_of("-");
-  size_t buildLoc = part.find_first_of("+");
+  const size_t preLoc = part.find_first_of("-");
+  const size_t buildLoc = part.find_first_of("+");
 
   if (preLoc != string::npos) {
-    size_t length = (buildLoc != string::npos ) ? (buildLoc -1) - preLoc : string::npos;
+    const ize_t length = (buildLoc != string::npos ) ? (buildLoc -1) - preLoc : string::npos;
     m_prereleaseVersion = part.substr(preLoc+1, length);
   }
 

--- a/src/lib/semantic_version_v2.cpp
+++ b/src/lib/semantic_version_v2.cpp
@@ -175,7 +175,8 @@ Version::Version(const string& s)
   size_t buildLoc = part.find_first_of("+");
 
   if (preLoc != string::npos) {
-    m_prereleaseVersion = part.substr(preLoc + 1, buildLoc);
+    size_t length = (buildLoc != string::npos ) ? (buildLoc -1) - preLoc : string::npos;
+    m_prereleaseVersion = part.substr(preLoc+1, length);
   }
 
   if (buildLoc != string::npos) {

--- a/src/lib/semantic_version_v2.cpp
+++ b/src/lib/semantic_version_v2.cpp
@@ -168,11 +168,19 @@ Version::Version(const string& s)
   m_majorVersion = static_cast<unsigned int>(strtoul(part.c_str(), 0, 0));
   if (!getline(ss, part, '.')) return;
   m_minorVersion = static_cast<unsigned int>(strtoul(part.c_str(), 0, 0));
-  if (!getline(ss, part, '-')) return;
+  if (!getline(ss, part)) return;
   m_patchVersion = static_cast<unsigned int>(strtoul(part.c_str(), 0, 0));
 
-  if (!getline(ss, m_prereleaseVersion, '+')) return;
-  getline(ss, m_buildVersion, '\0');
+  int preLoc = part.find_first_of("-");
+  int buildLoc = part.find_first_of("+");
+
+  if (preLoc != string::npos) {
+    m_prereleaseVersion = part.substr(preLoc, buildLoc);
+  }
+
+  if (buildLoc != string::npos) {
+    m_buildVersion = part.substr(buildLoc, string::npos);
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -255,6 +255,14 @@ DEF_TEST(ConstructFromString, SemanticVersion)
   return s.str() == "1.2.3-alpha.2+build.1234";
 }
 
+DEF_TEST(ConstructFromStringOnlyPrerelease, SemanticVersion)
+{
+  Version v("1.2.3-alpha.2");
+  ostringstream s;
+  s << v;
+  return s.str() == "1.2.3-alpha.2";
+}
+
 DEF_TEST(ConstructFromStringOnlyMeta, SemanticVersion)
 {
   Version v("1.2.3+build.1234");
@@ -274,6 +282,12 @@ DEF_TEST(ConstructFromStringNoPrereleaseNoMeta, SemanticVersion)
 DEF_TEST(WellFormed, SemanticVersion)
 {
   Version v("1.2.3-alpha.2+build.1234");
+  return v.IsWellFormed();
+}
+
+DEF_TEST(WellFormedOnlyPrerelease, SemanticVersion)
+{
+  Version v("1.2.3-alpha.2");
   return v.IsWellFormed();
 }
 

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -265,10 +265,10 @@ DEF_TEST(ConstructFromStringOnlyMeta, SemanticVersion)
 
 DEF_TEST(ConstructFromStringNoPrereleaseNoMeta, SemanticVersion)
 {
-  Version v("1.2.3+build.1234");
+  Version v("1.2.3");
   ostringstream s;
   s << v;
-  return s.str() == "1.2.3+build.1234";
+  return s.str() == "1.2.3";
 }
 
 DEF_TEST(WellFormed, SemanticVersion)

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -309,6 +309,12 @@ DEF_TEST(ParseIllFormed, SemanticVersion)
   return !v.IsWellFormed();
 }
 
+DEF_TEST(ParseIllFormed, SemanticVersion)
+{
+  Version v("1.2.3+build+1234-alpha-2");
+  return !v.IsWellFormed();
+}
+
 namespace testinator
 {
   template <>

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -309,7 +309,7 @@ DEF_TEST(ParseIllFormed, SemanticVersion)
   return !v.IsWellFormed();
 }
 
-DEF_TEST(ParseIllFormed, SemanticVersion)
+DEF_TEST(ParseIllFormedSwapped, SemanticVersion)
 {
   Version v("1.2.3+build+1234-alpha-2");
   return !v.IsWellFormed();

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -263,6 +263,14 @@ DEF_TEST(ConstructFromStringOnlyMeta, SemanticVersion)
   return s.str() == "1.2.3+build.1234";
 }
 
+DEF_TEST(ConstructFromStringNoPrereleaseNoMeta, SemanticVersion)
+{
+  Version v("1.2.3+build.1234");
+  ostringstream s;
+  s << v;
+  return s.str() == "1.2.3+build.1234";
+}
+
 DEF_TEST(WellFormed, SemanticVersion)
 {
   Version v("1.2.3-alpha.2+build.1234");
@@ -272,6 +280,12 @@ DEF_TEST(WellFormed, SemanticVersion)
 DEF_TEST(WellFormedOnlyMeta, SemanticVersion)
 {
   Version v("1.2.3+build.1234");
+  return v.IsWellFormed();
+}
+
+DEF_TEST(WellFormedNoPrereleaseNoMeta, SemanticVersion)
+{
+  Version v("1.2.3");
   return v.IsWellFormed();
 }
 

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -255,9 +255,23 @@ DEF_TEST(ConstructFromString, SemanticVersion)
   return s.str() == "1.2.3-alpha.2+build.1234";
 }
 
+DEF_TEST(ConstructFromStringOnlyMeta, SemanticVersion)
+{
+  Version v("1.2.3+build.1234");
+  ostringstream s;
+  s << v;
+  return s.str() == "1.2.3+build.1234";
+}
+
 DEF_TEST(WellFormed, SemanticVersion)
 {
   Version v("1.2.3-alpha.2+build.1234");
+  return v.IsWellFormed();
+}
+
+DEF_TEST(WellFormedOnlyMeta, SemanticVersion)
+{
+  Version v("1.2.3+build.1234");
   return v.IsWellFormed();
 }
 


### PR DESCRIPTION
Add support for build metadata without pre-release version as per spec-items 9 & 10

https://semver.org/#spec-item-9
https://semver.org/#spec-item-10 